### PR TITLE
Bump compat for FlameGraphs to v0.2 and Drop support for v0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Colors = "0.10, 0.11"
-FlameGraphs = "0.1"
+FlameGraphs = "0.2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
The default color scheme has changed in FlameGraphs v0.2. (I changed it.)
preview: https://kimikage.github.io/ProfileSVG.jl/previews/PR31/

The problem with the path separator also be fixed. 
https://kimikage.github.io/ProfileSVG.jl/previews/PR31/coloration-schemes/#Stack-frame-category-1