### PR TITLE
Add support for `width`, `height` and `font` options

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(
     pages=[
         "Introduction" => "index.md",
         "Coloration Schemes" => "coloration-schemes.md",
+        "Other Options" => "other-options.md",
         "Reference" => "reference.md",
     ]
 )

--- a/docs/src/assets/profile_test.jl
+++ b/docs/src/assets/profile_test.jl
@@ -1,3 +1,4 @@
+using FlameGraphs
 using Base.StackTraces: StackFrame
 
 function stackframe(func, file, line; C=false, inlined=false)
@@ -81,3 +82,5 @@ lidict = Dict{UInt64,StackFrame}(
     41 => stackframe(:similar, ".\\array.jl", 361),
     98 => stackframe(:jl_apply_generic, "gf.c", 2318, C=true),
     99 => stackframe(:jl_gc_collect, "gc.c", 3105, C=true))
+
+g = flamegraph(backtraces, lidict=lidict)

--- a/docs/src/coloration-schemes.md
+++ b/docs/src/coloration-schemes.md
@@ -6,10 +6,12 @@ See the [FlameGraphs docmentation](https://timholy.github.io/FlameGraphs.jl/stab
 for details.
 
 ```@setup ex
-using Profile, ProfileSVG # hide
+using Profile, ProfileSVG
+ProfileSVG.init()
 include(joinpath("assets", "profile_test.jl"))
 Profile.clear()
 @profile (x -> log(x) * exp(x)).(fill(1.23, 10, 10))
+ProfileSVG.set_default(width=800)
 ```
 
 ## Default scheme
@@ -21,7 +23,7 @@ or
 ```@example ex
 using FlameGraphs
 ProfileSVG.view(FlameColors())
-ProfileSVG.view(FlameColors(), backtraces, lidict=lidict) # hide
+ProfileSVG.view(FlameColors(), g) # hide
 ```
 The default scheme uses cycling colors to distinguish different stack frames,
 while coloring runtime dispatch "red" and garbage-collection "orange". The
@@ -34,7 +36,7 @@ You can colorize the stack frames based on their category, or module-of-origin.
 ```@example ex
 using FlameGraphs
 ProfileSVG.view(StackFrameCategory())
-ProfileSVG.view(StackFrameCategory(), backtraces, lidict=lidict) # hide
+ProfileSVG.view(StackFrameCategory(), g) # hide
 ```
 In the default `StackFrameCategory` scheme, "gray" indicates time spent in
 `Core.Compiler` (mostly inference), "dark gray" in other `Core`, "yellow" in

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,6 +41,7 @@ end
 profile_test(1)   # run once to compile
 
 using Profile, ProfileSVG
+ProfileSVG.init() # hide
 
 @profview profile_test(10)
 nothing # hide

--- a/docs/src/other-options.md
+++ b/docs/src/other-options.md
@@ -1,0 +1,53 @@
+# Other Options
+[`ProfileSVG.view`](@ref) and [`ProfileSVG.save`](@ref) have optional keyword
+arguments for specifying the SVG styles.
+
+```@setup ex
+using Profile, ProfileSVG
+ProfileSVG.init()
+include(joinpath("assets", "profile_test.jl"))
+Profile.clear()
+@profile (x -> log(x) * exp(x)).(fill(1.23, 10, 10))
+ProfileSVG.set_default(width=800)
+```
+
+## `width` and `height`
+The `width` and `height` options specify the size of the SVG image in pixels.
+However, the actual display scale depends on the viewer.
+
+If you set the `height` to `0`, it will be calculated automatically according to
+the graph. As shown below, cropping can occur when the height of the graph
+exceeds the manually specified `height`. When the interactive feature is
+available, you can display the cropped area by dragging the graph.
+
+```@example ex
+ProfileSVG.view(width=400, height=200)
+ProfileSVG.view(g, width=400, height=200) # hide
+```
+
+## `font` and `fontsize`
+
+The `font` option specifies the font family names for texts. This setting is
+used as the CSS font-family property, i.e. you can use a comma-separated list
+and quotes are required around the names which are not valid CSS identifiers.
+
+The `fontsize` option specifies the font size in pixels.
+
+Note that the actual rendering results depend on the viewer.
+
+```@example ex
+ProfileSVG.view(font="'Times New Roman', serif", fontsize=16)
+ProfileSVG.view(g, font="'Times New Roman', serif", fontsize=16) # hide
+```
+
+## Setting options as default
+You can specify the default values for options with
+[`ProfileSVG.set_default`](@ref).
+
+You can also reset the settings with [`ProfileSVG.init`](@ref).
+
+```@example ex
+ProfileSVG.set_default(StackFrameCategory(), fontsize=8)
+ProfileSVG.view(width=300)
+ProfileSVG.view(g, width=300) # hide
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -4,4 +4,6 @@
 @profview
 ProfileSVG.view
 ProfileSVG.save
+ProfileSVG.set_default
+ProfileSVG.init
 ```

--- a/src/ProfileSVG.jl
+++ b/src/ProfileSVG.jl
@@ -19,36 +19,152 @@ macro profview(ex)
     end
 end
 
+function flamegraph_kwargs(kwargs)
+    gopts = copy(default_config.graph_options)
+
+    keywords = (:lidict, :C, :combine, :recur, :norepl, :pruned, :filter)
+    for (k, v) in kwargs
+        if k in keywords
+            gopts[k] = v
+        end
+    end
+    gopts
+end
+
 struct FGConfig
-    g::FlameGraph
+    g::Union{FlameGraph, Nothing}
+    graph_options::Dict{Symbol, Any}
     fcolor
-    fontsize::Int
+    width::Real
+    height::Real
+    font::AbstractString
+    fontsize::Real
+end
+
+function FGConfig(g::Union{FlameGraph, Nothing} = nothing,
+                  graph_options = nothing,
+                  fcolor               = default_config.fcolor;
+                  width::Real          = default_config.width,
+                  height::Real         = default_config.height,
+                  font::AbstractString = default_config.font,
+                  fontsize::Real       = default_config.fontsize,
+                  kwargs...)
+
+    gopts = graph_options === nothing ? flamegraph_kwargs(kwargs) : graph_options
+    FGConfig(g, gopts, fcolor, width, height, font, fontsize)
+end
+
+
+"""
+    ProfileSVG.init()
+
+Initialize the settings.
+"""
+function init()
+    global default_config = FGConfig(nothing,
+                                     Dict{Symbol, Any}(),
+                                     FlameGraphs.default_colors,
+                                     width=960,
+                                     height=0,
+                                     font="inherit",
+                                     fontsize=12)
+    nothing
+end
+
+
+"""
+    ProfileSVG.set_default([fcolor]; kwargs...)
+
+Set defult configurations of profiling results. See [`ProfileSVG.view`](@ref)
+for details of `kwargs`.
+
+# Examples
+```julia
+ProfileSVG.set_default(width=600, fontsize=9)
+```
+"""
+function set_default(fcolor=default_config.fcolor; kwargs...)
+    global default_config = FGConfig(nothing, nothing, fcolor; kwargs...)
 end
 
 include("svgwriter.jl")
 
 """
-    ProfileSVG.view([fcolor], data=Profile.fetch(); fontsize=12, kwargs...)
+    ProfileSVG.view([fcolor,] data=Profile.fetch(); kwargs...)
+    ProfileSVG.view([fcolor,] g::FlameGraph; kwargs...)
 
-View profiling results. See [FlameGraphs](https://github.com/timholy/FlameGraphs.jl)
-for options for `kwargs` and the default value of `fcolor`.
+View profiling results.
+
+# keywords for SVG style
+- `width` (default: `960`)
+  - The width of output SVG image in pixels.
+- `height` (default: `0`)
+  - The height of output SVG image in pixels. If you set the height to `0`, it
+    will be calculated automatically according to the graph.
+- `font` (default: `"inherit"`)
+  - The font family names for texts. This setting is used as the CSS
+    `font-family` property, i.e. you can use a comma-separated list.
+- `fontsize` (default: `12`)
+  - The font size of texts for function information, in pixels (not points).
+
+# keywords for `flamegraph`
+- `lidict`
+- `C`
+- `combine`
+- `recur`
+- `pruned`
+- `filter`
+See [FlameGraphs](https://timholy.github.io/FlameGraphs.jl/stable/reference/#FlameGraphs.flamegraph)
+for details.
 """
-function view(fcolor, data::Vector{UInt64}=Profile.fetch(); fontsize::Integer=12, kwargs...)
-    g = flamegraph(data; kwargs...)
-    FGConfig(g, fcolor, fontsize)
+function view(fcolor, data::Vector{<:Unsigned}=Profile.fetch(); kwargs...)
+    gopts = flamegraph_kwargs(kwargs)
+    g = flamegraph(data; gopts...)
+    FGConfig(g, gopts, fcolor; kwargs...)
 end
-function view(data::Vector{UInt64}=Profile.fetch(); fontsize::Integer=12, kwargs...)
-    view(FlameGraphs.default_colors, data; fontsize=fontsize, kwargs...)
+function view(data::Vector{<:Unsigned}=Profile.fetch(); kwargs...)
+    gopts = flamegraph_kwargs(kwargs)
+    g = flamegraph(data; gopts...)
+    FGConfig(g, gopts; kwargs...)
+end
+function view(fcolor, g::FlameGraph; kwargs...)
+    FGConfig(g, nothing, fcolor; kwargs...)
+end
+function view(g::FlameGraph; kwargs...)
+    FGConfig(g; kwargs...)
 end
 
 """
-    ProfileSVG.save([fcolor], io, g=flamegraph(); kwargs...)
+    ProfileSVG.save([fcolor,] io::IO, data=Profile.fetch(); kwargs...)
+    ProfileSVG.save([fcolor,] io::IO, g::FlameGraph; kwargs...)
+    ProfileSVG.save([fcolor,] filename, data=Profile.fetch(); kwargs...)
+    ProfileSVG.save([fcolor,] filename, g::FlameGraph; kwargs...)
 
-Save profile results as an SVG file. See [FlameGraphs](https://github.com/timholy/FlameGraphs.jl)
-for options for `kwargs` and the default value of `fcolor`.
+Save profile results as an SVG file. See [`ProfileSVG.view`](@ref) for details
+of `kwargs`.
 """
-function save(fcolor, io::IO, g::FlameGraph; fontsize::Integer=12)
-    show(io, MIME("image/svg+xml"), FGConfig(g, fcolor, fontsize))
+function save(fcolor, io::IO, data::Vector{<:Unsigned}=Profile.fetch(); kwargs...)
+    gopts = flamegraph_kwargs(kwargs)
+    g = flamegraph(data; gopts...)
+    show(io, MIME("image/svg+xml"), FGConfig(g, gopts, fcolor; kwargs...))
+end
+function save(fcolor, io::IO, g::FlameGraph; kwargs...)
+    show(io, MIME("image/svg+xml"), FGConfig(g, nothing, fcolor; kwargs...))
+end
+function save(io::IO, data::Vector{<:Unsigned}=Profile.fetch(); kwargs...)
+    gopts = flamegraph_kwargs(kwargs)
+    g = flamegraph(data; gopts...)
+    show(io, MIME("image/svg+xml"), FGConfig(g, gopts; kwargs...))
+end
+function save(io::IO, g::FlameGraph; kwargs...)
+    show(io, MIME("image/svg+xml"), FGConfig(g; kwargs...))
+end
+
+function save(fcolor, filename::AbstractString, data::Vector{<:Unsigned}=Profile.fetch(); kwargs...)
+    open(filename, "w") do file
+        save(fcolor, file, data; kwargs...)
+    end
+    return nothing
 end
 function save(fcolor, filename::AbstractString, g::FlameGraph; kwargs...)
     open(filename, "w") do file
@@ -56,41 +172,45 @@ function save(fcolor, filename::AbstractString, g::FlameGraph; kwargs...)
     end
     return nothing
 end
-function save(fcolor, io::IO; fontsize::Integer=12, kwargs...)
-    g = flamegraph(; kwargs...)
-    save(fcolor, io, g; fontsize=fontsize)
-end
-function save(fcolor, filename::AbstractString; kwargs...)
+function save(filename::AbstractString, data::Vector{<:Unsigned}=Profile.fetch(); kwargs...)
     open(filename, "w") do file
-        save(fcolor, file; kwargs...)
+        save(file, data; kwargs...)
     end
     return nothing
 end
-save(io::IO, args...; kwargs...) = save(FlameGraphs.default_colors, io, args...; kwargs...)
-save(filename::AbstractString, args...; kwargs...) = save(FlameGraphs.default_colors, filename, args...; kwargs...)
+function save(filename::AbstractString, g::FlameGraph; kwargs...)
+    open(filename, "w") do file
+        save(file, g; kwargs...)
+    end
+    return nothing
+end
 
 
 Base.showable(::MIME"image/svg+xml", fg::FGConfig) = true
 
 
 function Base.show(io::IO, ::MIME"image/svg+xml", fg::FGConfig)
-    g, fcolor, fontsize = fg.g, fg.fcolor, fg.fontsize
+    g, fcolor = fg.g, fg.fcolor
     ncols, nrows = length(g.data.span), FlameGraphs.depth(g)
-    leftmargin = rightmargin = 10
-    width = 1000
-    topmargin = 30
-    botmargin = 40
-    rowheight = 15
-    height = ceil(rowheight*nrows + botmargin + topmargin)
-    xstep = (width - (leftmargin + rightmargin)) / ncols
-    ystep = (height - (topmargin + botmargin)) / nrows
+    width = fg.width
+    leftmargin = rightmargin = round(Int, width * 0.01)
+    topmargin = botmargin = round(Int, max(width * 0.04, fg.fontsize * 3))
 
-    function flamerects(fcolor, io::IO, g, j, nextidx)
+    xstep = (width - (leftmargin + rightmargin)) / ncols
+    ystep = round(Int, fg.fontsize * 1.25)
+
+    if fg.height <= 0
+        height = ceil(ystep * nrows + botmargin + topmargin)
+    else
+        height = fg.height
+    end
+
+    function flamerects(io::IO, g, j, nextidx)
         ndata = g.data
         sf = ndata.sf
-        thiscolor = fcolor(nextidx, j, ndata)
+        color = fcolor(nextidx, j, ndata)
         x = (first(ndata.span)-1) * xstep + leftmargin
-        y = height - j*ystep - botmargin
+        y = height - j * ystep - botmargin
         w = length(ndata.span) * xstep
         file = string(sf.file)
         m = match(r"[^\\/]+$", file)
@@ -102,10 +222,10 @@ function Base.show(io::IO, ::MIME"image/svg+xml", fg::FGConfig)
             basename = file
         end
         shortinfo = "$(sf.func) in $basename:$(sf.line)"
-        write_svgflamerect(io, x, y, w, ystep, shortinfo, dirinfo, thiscolor)
+        write_svgflamerect(io, x, y, w, ystep, shortinfo, dirinfo, color)
 
         for c in g
-            flamerects(fcolor, io, c, j+1, nextidx)
+            flamerects(io, c, j + 1, nextidx)
         end
         return nothing
     end
@@ -114,12 +234,14 @@ function Base.show(io::IO, ::MIME"image/svg+xml", fg::FGConfig)
 
     write_svgdeclaration(io)
 
-    write_svgheader(io, fig_id, width, height, "Verdana", fontsize)
+    write_svgheader(io, fig_id, width, height, fg.font, fg.fontsize)
 
     nextidx = fill(1, nrows)
-    flamerects(fcolor, io, g, 1, nextidx)
+    flamerects(io, g, 1, nextidx)
 
     write_svgfooter(io, fig_id)
 end
+
+__init__() = init()
 
 end # module

--- a/src/svgwriter.jl
+++ b/src/svgwriter.jl
@@ -29,7 +29,10 @@ function write_svgdeclaration(io::IO)
 end
 
 function write_svgheader(io::IO, fig_id, width, height, font, fontsize)
-    caption_size = 17 # FIXME
+    caption_size = simplify(fontsize * 1.4)
+    x_cap = simplify(width * 0.5)
+    y_cap = simplify(fontsize * 2)
+    x_msg = simplify(fontsize * 0.8)
     y_msg = height - caption_size
     fontcolorhex = "#000000" # FIXME
     bg_fill = """url(#$fig_id-background)"""
@@ -75,9 +78,7 @@ function write_svgheader(io::IO, fig_id, width, height, font, fontsize)
         </style>
         <g id="$fig_id-frame" clip-path="url(#$fig_id-clip)">
         <rect id="$fig_id-bg" x="0" y="0" width="$width" height="$height"/>
-        <text id="$fig_id-caption" x="600" y="24">Profile results</text>
-        <text x="10" y="$y_msg">Function:</text>
-        <text x="70" y="$y_msg" id="$fig_id-details"> </text>
+        <text id="$fig_id-caption" x="$x_cap" y="$y_cap">Profile results</text>
         <g id="$fig_id-viewport" transform="scale(1)">
         """)
 end
@@ -85,7 +86,7 @@ end
 function write_svgflamerect(io::IO, xstart, ystart, w, h, shortinfo, dirinfo, color)
     x = simplify(xstart)
     y = simplify(ystart)
-    yt = simplify(y + 11.5) # FIXME
+    yt = simplify(y + h * 0.75)
     width = simplify(w)
     height = simplify(h)
     sinfo = escape_html(shortinfo)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,27 @@
 using ProfileSVG
 using Test
 
-# For these tests to work you need `rsvg-convert` installed.
-# On Ubuntu this is `sudo apt install librsvg2-bin`.
+using FlameGraphs
+using Base.StackTraces: StackFrame
+
+function stackframe(func, file, line; C=false, inlined=false)
+    StackFrame(Symbol(func), Symbol(file), line, nothing, C, inlined, 0)
+end
+
+backtraces = UInt[0, 4, 3, 2, 1,
+                  0, 4, 3, 2, 1,
+                  0,    6, 5, 1,
+                  0,       8, 7,
+                  0]
+
+lidict = Dict{UInt64,StackFrame}(1=>stackframe(:f1, :file1, 1),
+                                 2=>stackframe(:jl_f, :filec, 55; C=true),
+                                 3=>stackframe(:jl_invoke, :file2, 1; C=true),
+                                 4=>stackframe(:_ZL, Symbol("libLLVM-8.0.so"), 15),
+                                 5=>stackframe(:f4, :file1, 20),
+                                 6=>stackframe(:copy, Symbol(".\\expr.jl"), 1),
+                                 7=>stackframe(:f1, :file1, 2),
+                                 8=>stackframe(:typeinf, Symbol("./compiler/typeinfer.jl"), 10))
 
 function profile_test(n)
     for i = 1:n
@@ -16,14 +35,176 @@ function profile_test(n)
     end
 end
 
-@testset "ProfileSVG.jl" begin
+@test detect_ambiguities(ProfileSVG, imported=true, recursive=true) == []
+
+@testset "view" begin
+    sfc = StackFrameCategory()
+
+    fg = ProfileSVG.view(sfc, backtraces,
+                          C=true, lidict=lidict, width=123.4, unknown=nothing)
+    @test Base.showable(MIME"image/svg+xml"(), fg)
+    @test FlameGraphs.depth(fg.g) == 5
+    @test fg.fcolor isa StackFrameCategory
+    @test fg.graph_options[:C] == true
+    @test fg.graph_options[:lidict] == lidict
+    @test fg.width == 123.4
+    @test fg.height == 0
+    @test fg.font == "inherit"
+    @test fg.fontsize == 12
+
+    fg = ProfileSVG.view(backtraces,
+                          C=true, lidict=lidict, fontsize=12.34, unknown=missing)
+    @test FlameGraphs.depth(fg.g) == 5
+    @test fg.fcolor isa FlameColors
+    @test fg.graph_options[:C] == true
+    @test fg.graph_options[:lidict] == lidict
+    @test fg.width == 960
+    @test fg.height == 0
+    @test fg.font == "inherit"
+    @test fg.fontsize == 12.34
+
+    g = flamegraph(backtraces, lidict=lidict)
+
+    fg = ProfileSVG.view(sfc, g, C=true, height=123.4, unknown=true)
+    @test FlameGraphs.depth(fg.g) == 4 # `C` option does not affect the graph
+    @test fg.fcolor isa StackFrameCategory
+    @test fg.graph_options[:C] == true
+    @test fg.width == 960
+    @test fg.height == 123.4
+    @test fg.font == "inherit"
+    @test fg.fontsize == 12
+
+    fg = ProfileSVG.view(g, C=true, font="serif", unknown=false)
+    @test FlameGraphs.depth(fg.g) == 4 # `C` option does not affect the graph
+    @test fg.fcolor isa FlameColors
+    @test fg.graph_options[:C] == true
+    @test fg.width == 960
+    @test fg.height == 0
+    @test fg.font == "serif"
+    @test fg.fontsize == 12
+end
+
+@testset "save" begin
+    io = IOBuffer()
+    sfc = StackFrameCategory()
+
+    function svg_size(str)
+        m = match(Regex("""<svg version="1.1" width="([^"]+)" height="([^"]+)" """), str)
+        m === nothing && error("svg size is unknown")
+        (m.captures[1], m.captures[2])
+    end
+    function has_filled_rect(str, color)
+        occursin(Regex("""<rect[^/]+fill="$color" """), str)
+    end
+
+    ProfileSVG.save(sfc, io, backtraces,
+                    C=true, lidict=lidict, width=123.4, unknown=nothing)
+    str = String(take!(io))
+    @test svg_size(str) == ("123.4", "147")
+    @test has_filled_rect(str, "#FF0000")
+    filename = tempname()
+    ProfileSVG.save(sfc, filename, backtraces,
+                    C=true, lidict=lidict, width=123.4, unknown=nothing)
+    str = read(filename, String)
+    rm(filename)
+    @test svg_size(str) == ("123.4", "147")
+    @test has_filled_rect(str, "#FF0000")
+
+    ProfileSVG.save(io, backtraces,
+                    C=true, lidict=lidict, fontsize=12.34, unknown=missing)
+    str = String(take!(io))
+    @test svg_size(str) == ("960", "151")
+    @test !has_filled_rect(str, "#FF0000")
+    filename = tempname()
+    ProfileSVG.save(filename, backtraces,
+                    C=true, lidict=lidict, fontsize=12.34, unknown=missing)
+    str = read(filename, String)
+    rm(filename)
+    @test svg_size(str) == ("960", "151")
+    @test !has_filled_rect(str, "#FF0000")
+
+
+    g = flamegraph(backtraces, lidict=lidict)
+
+    ProfileSVG.save(sfc, io, g, C=true, height=123.4, unknown=true)
+    str = String(take!(io))
+    @test svg_size(str) == ("960", "123.4")
+    @test has_filled_rect(str, "#FF0000")
+    filename = tempname()
+    ProfileSVG.save(sfc, filename, g, C=true, height=123.4, unknown=true)
+    str = read(filename, String)
+    rm(filename)
+    @test svg_size(str) == ("960", "123.4")
+    @test has_filled_rect(str, "#FF0000")
+
+    ProfileSVG.save(io, g, C=true, font="serif", unknown=false)
+    str = String(take!(io))
+    @test svg_size(str) == ("960", "136")
+    @test !has_filled_rect(str, "#FF0000")
+    filename = tempname()
+    ProfileSVG.save(filename, g, C=true, font="serif", unknown=false)
+    str = read(filename, String)
+    rm(filename)
+    @test svg_size(str) == ("960", "136")
+    @test !has_filled_rect(str, "#FF0000")
+end
+
+@testset "set_default" begin
+    sfc = StackFrameCategory()
+
+    ProfileSVG.set_default(sfc, C=true, height=567.8)
+
+    fgc = ProfileSVG.view(sfc, backtraces,
+                          C=false, lidict=lidict, width=123.4, unknown=nothing)
+    @test FlameGraphs.depth(fgc.g) == 4
+    @test fgc.fcolor isa StackFrameCategory
+    @test fgc.graph_options[:C] == false
+    @test fgc.graph_options[:lidict] == lidict
+    @test fgc.width == 123.4
+    @test fgc.height == 567.8
+    @test fgc.font == "inherit"
+    @test fgc.fontsize == 12
+
+    ProfileSVG.set_default(fontsize=9)
+    fgc = ProfileSVG.view(backtraces,
+                          lidict=lidict, width=123.4, unknown=nothing)
+    @test FlameGraphs.depth(fgc.g) == 5
+    @test fgc.fcolor isa StackFrameCategory
+    @test fgc.graph_options[:C] == true
+    @test fgc.graph_options[:lidict] == lidict
+    @test fgc.width == 123.4
+    @test fgc.height == 567.8
+    @test fgc.font == "inherit"
+    @test fgc.fontsize == 9
+
+    ProfileSVG.init()
+    fgc = ProfileSVG.view(backtraces,
+                          C=true, lidict=lidict, width=123.4, unknown=nothing)
+    @test FlameGraphs.depth(fgc.g) == 5
+    @test fgc.fcolor isa FlameColors
+    @test fgc.graph_options[:C] == true
+    @test fgc.graph_options[:lidict] == lidict
+    @test fgc.width == 123.4
+    @test fgc.height == 0
+    @test fgc.font == "inherit"
+    @test fgc.fontsize == 12
+end
+
+# For these tests to work you need `rsvg-convert` installed.
+# On Ubuntu this is `sudo apt install librsvg2-bin`.
+@testset "profview" begin
     profile_test(1)   # to compile
     @profview profile_test(10)
+
     mktemp() do path, io
         ProfileSVG.save(io)
         flush(io)
-        # Validate the file by converting to PNG
-        str = read(`rsvg-convert $path`, String)
-        @test codeunits(str)[1:8] == UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+        try
+            # Validate the file by converting to PNG
+            str = read(`rsvg-convert $path`, String)
+            @test codeunits(str)[1:8] == UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+        catch e
+            e isa Base.IOError || rethrow()
+        end
     end
 end


### PR DESCRIPTION
This reduces the hard-coded numbers and makes the layout more flexible.
This also adds new API `set_default()` and `init()`.

preview: https://kimikage.github.io/ProfileSVG.jl/previews/PR34/

Fixes #8, Fixes #32, Fixes #33