### PR TITLE
Add support for `bgcolor`, `fontcolor` and `frameopacity`

### DIFF
--- a/docs/src/assets/pattern.svg
+++ b/docs/src/assets/pattern.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="svg_pattern" version="1.1" viewBox="0 0 208 120" height="120" width="208">
+<g style="opacity:0.15;fill:none" id="layer1">
+    <g id="g_hex3">
+      <g id="g_hex" style="stroke:#aaaaaa">
+        <path id="path_a" d="m 0,-32 27.7128,16 v 32 l -27.7128,16 -27.7128,-16 v -32 z" style="stroke-width:4" />
+        <path id="path_b" d="m 0,-24 20.7846,12 v 24 l -20.7846,12 -20.7846,-12 v -24 z" style="stroke-width:2" />
+      </g>
+      <g id="g_dots">
+        <circle r="5" cy="-6.5" id="circle_dot" style="fill:#aaaaaa" />
+        <use id="use_a" xlink:href="#circle_dot" transform="rotate(120)" />
+        <use id="use_b" xlink:href="#circle_dot" transform="rotate(-120)" />
+      </g>
+      <use id="use_hex2" xlink:href="#g_hex" x="69.282" />
+      <use id="use_hex3" xlink:href="#g_hex" x="-69.282" />
+    </g>
+    <use id="use_hex3_a" xlink:href="#g_hex3" x="208" y="0" />
+    <use id="use_hex3_b" xlink:href="#g_hex3" x="104" y="60" />
+    <use id="use_hex3_c" xlink:href="#g_hex3" x="0" y="120" />
+    <use id="use_hex3_d" xlink:href="#g_hex3" x="208" y="120" />
+  </g>
+</svg>

--- a/docs/src/assets/profilesvg.css
+++ b/docs/src/assets/profilesvg.css
@@ -3,4 +3,9 @@ article svg {
   overflow: auto;
   max-width: 100%;
   min-width: 500px;
+  border: 1px solid rgba(192, 192, 192, 0.2);
+}
+
+article div.bg {
+  background: url('pattern.svg');
 }

--- a/docs/src/coloration-schemes.md
+++ b/docs/src/coloration-schemes.md
@@ -43,7 +43,99 @@ In the default `StackFrameCategory` scheme, "gray" indicates time spent in
 LLVM, "orange" in other `ccalls`, "light blue" in `Base`, and "red" is
 uncategorized (mostly package code).
 
+## `bgcolor` and `fontcolor` options
+[`ProfileSVG.view`](@ref) and [`ProfileSVG.save`](@ref) have optional keyword
+arguments for specifying the SVG styles.
+
+The `bgcolor` option specifies the background color style and the `fontcolor`
+option specifies the font color style.
+
+One of the following symbols is available for `bgcolor`:
+- `:fcolor`
+  - `fcolor(:bg)` (default)
+- `:classic`
+  - pale color gradation which comes from the original
+    [Flame Graphs](http://www.brendangregg.com/flamegraphs.html)
+- `:transparent`
+  - fully transparent
+
+One of the following symbols is available for `fontcolor`:
+- `:fcolor`
+  - `fcolor(:font)` (default)
+- `:classic`
+  - black
+- `:currentcolor`
+  - the [`currentcolor`](https://www.w3.org/TR/css-color-3/#currentcolor) CSS keyword
+- `:bw`
+  - black or white depending on the frame color
 
 !!! info
-    The `colorbg` and `colorfont` options of `FlameGraphs.FlameColors` and
-    `FlameGraphs.StackFrameCategory` are currently not supported and ignored.
+    You cannot specify a `Color` or a color name directly to `bgcolor` or
+    `fontcolor`. The `colorbg` and `colorfont` options of
+    `FlameGraphs.FlameColors` and `FlameGraphs.StackFrameCategory` are
+    available.
+
+### `:fcolor` (default)
+```@example ex
+using FlameGraphs, Colors
+fcolor = FlameColors(colorbg=colorant"steelblue", colorfont=colorant"lightyellow")
+
+ProfileSVG.view(fcolor)
+ProfileSVG.view(fcolor, g) # hide
+```
+
+### `:classic`
+```@example ex
+ProfileSVG.view(bgcolor=:classic, fontcolor=:classic)
+ProfileSVG.view(g, bgcolor=:classic, fontcolor=:classic) # hide
+```
+
+### `:transparent` and `:currentcolor`
+```@raw html
+<div class="bg">
+```
+The contextual, i.e. parent, background here has a pattern, and the font color
+depends on the theme (light or dark).
+
+```@example ex
+ProfileSVG.view(bgcolor=:transparent, fontcolor=:currentcolor)
+ProfileSVG.view(g, bgcolor=:transparent, fontcolor=:currentcolor) # hide
+```
+```@raw html
+</div>
+```
+
+### `:bw`
+```@example ex
+modcat(mod) = nothing
+loccat(sf) = occursin("#", string(sf.func)) ? colorant"navy" : colorant"powderblue"
+
+mysfc = StackFrameCategory(modcat, loccat, colorant"dimgray", colorant"red")
+
+ProfileSVG.view(mysfc, fontcolor=:bw)
+ProfileSVG.view(mysfc, g, fontcolor=:bw) # hide
+```
+
+!!! info
+    The decision whether to use black or white is based on the assumption that
+    the frames are opaque. If the [`frameopacity` option](@ref) is set to a low
+    value, the texts may be hard to read.
+
+## `frameopacity` option
+
+The `frameopacity` option specifyies the opacity of frames in [0, 1]. This
+option affects only the background of the frame, not the texts or the viewport
+background.
+
+```@raw html
+<div class="bg">
+```
+The contextual background here has a pattern.
+
+```@example ex
+ProfileSVG.view(frameopacity=0.5, bgcolor=:transparent, fontcolor=:currentcolor)
+ProfileSVG.view(g, frameopacity=0.5, bgcolor=:transparent, fontcolor=:currentcolor) # hide
+```
+```@raw html
+</div>
+```

--- a/src/svgwriter.jl
+++ b/src/svgwriter.jl
@@ -23,12 +23,16 @@ function simplify(x::Real, digits=2)
     ra == rd ? Int(ra) : rd
 end
 
+isdarkcolor(c::Color) = gray(Gray(c)) < 0.65
+
 function write_svgdeclaration(io::IO)
     println(io, """<?xml version="1.0" standalone="no"?>""")
     println(io, """<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">""")
 end
 
-function write_svgheader(io::IO, fig_id, width, height, font, fontsize, notext)
+function write_svgheader(io::IO, fig_id, width, height,
+                         bgcolor, fontcolor, frameopacity,
+                         font, fontsize, notext)
     w = simplify(width)
     h = simplify(height)
     caption_size = simplify(fontsize * 1.4)
@@ -36,18 +40,31 @@ function write_svgheader(io::IO, fig_id, width, height, font, fontsize, notext)
     y_cap = simplify(fontsize * 2)
     x_msg = simplify(fontsize * 0.8)
     y_msg = height - caption_size
-    fontcolorhex = "#000000" # FIXME
-    bg_fill = """url(#$fig_id-background)"""
+    textcolor = isempty(fontcolor) ? "black" : fontcolor
+    caption_color = textcolor
+    if isempty(fontcolor) && startswith(bgcolor, "#") && isdarkcolor(parse(Gray, bgcolor))
+        caption_color = "white"
+    end
+    bg_fill = isempty(bgcolor) ? "url(#$fig_id-background)" : bgcolor
+    details_bg_fill = isempty(bgcolor) ? "white" : bgcolor
     text_stroke_opacity = notext ? 0.0 : 0.35
+    op = simplify(frameopacity)
+    hover_opacity = simplify(op > 0.75 ? op - 0.25 : op + 0.25)
     print(io,
         """
         <svg version="1.1" width="$w" height="$h" viewBox="0 0 $w $h"
              xmlns="http://www.w3.org/2000/svg" id="$fig_id">
         <defs>
+        """)
+    isempty(bgcolor) && print(io,
+        """
             <linearGradient id="$fig_id-background" y1="0" y2="1" x1="0" x2="0">
                 <stop stop-color="#eeeeee" offset="5%" />
                 <stop stop-color="#eeeeb0" offset="95%" />
             </linearGradient>
+        """)
+    print(io,
+        """
             <clipPath id="$fig_id-clip">
                 <rect x="0" y="0" width="$w" height="$h"/>
             </clipPath>
@@ -57,10 +74,11 @@ function write_svgheader(io::IO, fig_id, width, height, font, fontsize, notext)
                 pointer-events: none;
                 font-family: $font;
                 font-size: $(simplify(fontsize))px;
-                fill: $fontcolorhex;
+                fill: $textcolor;
             }
             text#$fig_id-caption {
                 font-size: $(caption_size)px;
+                fill: $caption_color;
                 text-anchor: middle;
             }
             #$fig_id-bg {
@@ -68,16 +86,35 @@ function write_svgheader(io::IO, fig_id, width, height, font, fontsize, notext)
             }
             #$fig_id-viewport rect, #$fig_id-viewport path {
                 vector-effect: non-scaling-stroke;
+                fill-opacity: $op;
             }
             #$fig_id-viewport text {
-                stroke: $fontcolorhex;
+                stroke: $textcolor;
                 stroke-width: 0;
                 stroke-opacity: $text_stroke_opacity;
             }
             #$fig_id-viewport rect:hover, #$fig_id-viewport path:hover {
-                stroke: $fontcolorhex;
-                stroke-width: 1;
+                fill-opacity: $hover_opacity;
+                stroke: $textcolor;
+                stroke-width: 0.5;
             }
+            #$fig_id-viewport + rect {
+                fill: $details_bg_fill;
+                opacity: 0.8;
+            }
+            text#$fig_id-details{
+                fill: $caption_color;
+            }
+        """)
+    isempty(fontcolor) && print(io,
+        """
+            #$fig_id-viewport text.w {
+                fill: white;
+                stroke: white;
+            }
+        """)
+    print(io,
+        """
         </style>
         <g id="$fig_id-frame" clip-path="url(#$fig_id-clip)">
         <rect id="$fig_id-bg" x="0" y="0" width="$w" height="$h"/>
@@ -87,7 +124,7 @@ function write_svgheader(io::IO, fig_id, width, height, font, fontsize, notext)
 end
 
 function write_svgflamerect(io::IO, xstart, ystart, width, height, roundradius,
-                            shortinfo, dirinfo, color)
+                            shortinfo, dirinfo, color, bw)
     x = simplify(xstart)
     y = simplify(ystart)
     yt = simplify(y + height * 0.75)
@@ -96,13 +133,14 @@ function write_svgflamerect(io::IO, xstart, ystart, width, height, roundradius,
     r = simplify(roundradius)
     sinfo = escape_html(shortinfo)
     dinfo = escape_html(dirinfo)
+    classw = (bw & isdarkcolor(color)) ? " class=\"w\"" : ""
     if r > zero(r)
         print(io, """<rect x="$x" y="$y" width="$w" height="$h" rx="$r" """)
     else
         print(io, """<path d="M$x,$(y)v$(h)h$(w)v-$(h)z" """)
     end
     println(io, """fill="#$(hex(color))" data-dinfo="$dinfo"/>""")
-    println(io, """<text x="$x" dx="4" y="$yt">$sinfo</text>""")
+    println(io, """<text x="$x" dx="4" y="$yt"$classw>$sinfo</text>""")
 end
 
 function write_svgfooter(io::IO, fig_id)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -72,6 +72,21 @@
             .replace(/&amp;/g, '&');
     };
 
+    var isDarkColor = function (c) {
+        var m = c.match(/^rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
+        if (m) {
+            return m[1] * 299 + m[2] * 587 + m[3] * 114 < 255 * 650;
+        }
+        m = c.match(/^#([\dA-F]{2})([\dA-F]{2})([\dA-F]{2})/i);
+        if (m) {
+            var r = parseInt(m[1], 16);
+            var g = parseInt(m[2], 16);
+            var b = parseInt(m[3], 16);
+            return r * 299 + g * 587 + b * 114 < 255 * 650;
+        }
+        return true;
+    };
+
     ProfileSVG.moveAndZoom = function (targetFocusX, targetScaleX, fig, deltaT) {
         if (typeof deltaT === 'undefined') {
             deltaT = DEFAULT_TRANSITION_TIME;
@@ -152,7 +167,7 @@
                     var path = p.node;
                     // The API compatibility of path segments is problematic.
                     var d = path.getAttribute('d');
-                    var values = d.match(/^M\s*([\d.]+)[\s,]+([\d.]+)[^h]+h\s*([\d.]+)/);
+                    var values = d.match(/^M\s*([\d.]+)[\s,]+(-?[\d.]+)[^h]+h\s*([\d.]+)/);
                     var x = Number(values[1]);
                     var y = Number(values[2]);
                     var w = Number(values[3]);
@@ -234,16 +249,19 @@
         detail.style.display = 'none';
         detail.style.visibility = 'visible';
 
-        detail.setAttribute('x', fig.charWidthM);
         detail.setAttribute('id', figId + '-details');
+        detail.setAttribute('x', fig.charWidthM);
         detail.setAttribute('y', fig.height - fig.textHeight * 0.75);
 
-        textBg.setAttribute('fill', 'white'); // FIXME
-        textBg.setAttribute('fill-opacity', '0.8');
         textBg.setAttribute('x', 0);
         textBg.setAttribute('y', fig.height - fig.textHeight * 2);
         textBg.setAttribute('width', fig.width);
         textBg.setAttribute('height', fig.textHeight * 2);
+        var textBgFill = getComputedStyle(textBg).fill;
+        if (textBgFill == "rgba(0, 0, 0, 0)" || textBgFill == "transparent") {
+            var isDark = isDarkColor(getComputedStyle(detail).fill);
+            textBg.style.fill = isDark ? 'white' : 'black';
+        }
         textBg.style.display = 'none';
 
         ProfileSVG.reset(fig);


### PR DESCRIPTION
This changes the default background style. (It doesn't affect functionality, but I labeled this PR as a breaking change because this makes a big difference in "impression".)
This also slightly changes the highlighting behavior.

https://kimikage.github.io/ProfileSVG.jl/previews/PR48/coloration-schemes/

~If you are satisfied with this change, I will add the tests.~ Done

Closes #40