### PR TITLE
Use system-ui font by default

### DIFF
--- a/src/ProfileSVG.jl
+++ b/src/ProfileSVG.jl
@@ -97,7 +97,7 @@ function init()
                                      width=960,
                                      height=0,
                                      roundradius=2,
-                                     font="inherit",
+                                     font="system-ui",
                                      fontsize=12,
                                      notext=false,
                                      timeunit=:none,


### PR DESCRIPTION
# Before

![Schermafbeelding 2022-01-05 om 12 04 44](https://user-images.githubusercontent.com/6933510/148207888-eb990176-8e55-42f8-8467-85fd2d0eb3aa.png)

# After
![Schermafbeelding 2022-01-05 om 12 05 12](https://user-images.githubusercontent.com/6933510/148207900-6363880f-1c40-4ae7-906d-a3f9249323d9.png)


# Info
`system-ui` is the font that your browser uses to render the 'chrome' UI: toolbars and menus. It is the most 'neutral' font for UI. `inherit` would use the default font by the display system, which is likely a font designed for paragraphs of text, not UI.

https://drafts.csswg.org/css-fonts-4/#system-ui-def