### PR TITLE
Add `title` option

### DIFF
--- a/docs/src/other-options.md
+++ b/docs/src/other-options.md
@@ -143,6 +143,9 @@ ProfileSVG.view(g, timeunit=:µs, delay=3e-4) # hide
     match the measurement time by `@time` etc. The discrepancies may also occur
     if the profiling environment and the viewing environment are different.
 
+## `title`
+The `title` option specifies the title (caption) of the graph.
+
 ## Setting options as default
 You can specify the default values for options with
 [`ProfileSVG.set_default`](@ref).
@@ -150,7 +153,8 @@ You can specify the default values for options with
 You can also reset the settings with [`ProfileSVG.init`](@ref).
 
 ```@example ex
-ProfileSVG.set_default(StackFrameCategory(), roundradius=0, font="system-ui", fontsize=8)
+ProfileSVG.set_default(StackFrameCategory(), roundradius=0, title="<default>",
+                       font="system-ui", fontsize=8)
 ProfileSVG.view(width=300)
 ProfileSVG.view(g, width=300) # hide
 ```

--- a/src/ProfileSVG.jl
+++ b/src/ProfileSVG.jl
@@ -49,6 +49,7 @@ struct FGConfig
     notext::Bool
     timeunit::Symbol
     delay::Float64
+    title::String
 end
 
 function FGConfig(g::Union{FlameGraph, Nothing} = nothing,
@@ -68,6 +69,7 @@ function FGConfig(g::Union{FlameGraph, Nothing} = nothing,
                   notext::Bool         = default_config.notext,
                   timeunit::Symbol     = default_config.timeunit,
                   delay::Real          = default_config.delay,
+                  title::String        = default_config.title,
                   kwargs...)
 
     gopts = graph_options === nothing ? flamegraph_kwargs(kwargs) : graph_options
@@ -75,7 +77,7 @@ function FGConfig(g::Union{FlameGraph, Nothing} = nothing,
     FGConfig(g, gopts, fcolor,
              bgcolor, fontcolor, frameopacity,
              yflip, maxdepth, maxframes, width, height, roundradius,
-             font, fontsize, notext, timeunit, delay)
+             font, fontsize, notext, timeunit, delay, title)
 end
 
 
@@ -101,7 +103,8 @@ function init()
                                      fontsize=12,
                                      notext=false,
                                      timeunit=:none,
-                                     delay=0.0)
+                                     delay=0.0,
+                                     title = "Profile results")
     nothing
 end
 
@@ -163,6 +166,8 @@ View profiling results.
 - `delay` (default: `0.0`)
   - The delay between backtraces, in seconds. If a non-positive number is
     specified, the current setting in `Profile.init()` will be used.
+- `title` (default: `"Profile results"`)
+  - The title of the profile plot.
 
 # keywords for `flamegraph`
 - `lidict`
@@ -328,7 +333,7 @@ function show_flamegraph_body(io::IO, fg::FGConfig)
 
     write_svgheader(io, fig_id, width, height,
                     bgcolor(fg), fontcolor(fg), fg.frameopacity,
-                    fg.font, fg.fontsize, fg.notext, xstep, fg.timeunit, fg.delay)
+                    fg.font, fg.fontsize, fg.notext, xstep, fg.timeunit, fg.delay, fg.title)
 
     nextidx = fill(1, nrows + 1) # nextidx[end]: framecount
     flamerects(io, fg.g, 1, nextidx)

--- a/src/ProfileSVG.jl
+++ b/src/ProfileSVG.jl
@@ -104,7 +104,7 @@ function init()
                                      notext=false,
                                      timeunit=:none,
                                      delay=0.0,
-                                     title = "Profile results")
+                                     title="Profile results")
     nothing
 end
 
@@ -167,7 +167,7 @@ View profiling results.
   - The delay between backtraces, in seconds. If a non-positive number is
     specified, the current setting in `Profile.init()` will be used.
 - `title` (default: `"Profile results"`)
-  - The title of the profile plot.
+  - The title (caption) of the graph.
 
 # keywords for `flamegraph`
 - `lidict`

--- a/src/svgwriter.jl
+++ b/src/svgwriter.jl
@@ -34,7 +34,7 @@ end
 
 function write_svgheader(io::IO, fig_id, width, height,
                          bgcolor, fontcolor, frameopacity,
-                         font, fontsize, notext, xstep, timeunit, delay)
+                         font, fontsize, notext, xstep, timeunit, delay, title)
     w = simplify(width)
     h = simplify(height)
     caption_size = simplify(fontsize * 1.4)
@@ -123,7 +123,7 @@ function write_svgheader(io::IO, fig_id, width, height,
         </style>
         <g id="$fig_id-frame" clip-path="url(#$fig_id-clip)">
         <rect id="$fig_id-bg" x="0" y="0" width="$w" height="$h"/>
-        <text id="$fig_id-caption" x="$x_cap" y="$y_cap">Profile results</text>
+        <text id="$fig_id-caption" x="$x_cap" y="$y_cap">$title</text>
         <g id="$fig_id-viewport" transform="scale(1)"$dataxstep$datatunit$datadelay>
         """)
 end

--- a/src/svgwriter.jl
+++ b/src/svgwriter.jl
@@ -37,15 +37,15 @@ function write_svgheader(io::IO, fig_id, width, height,
                          font, fontsize, notext, xstep, timeunit, delay, title)
     w = simplify(width)
     h = simplify(height)
-    caption_size = simplify(fontsize * 1.4)
-    x_cap = simplify(width * 0.5)
-    y_cap = simplify(fontsize * 2)
+    title_size = simplify(fontsize * 1.4)
+    x_title = simplify(width * 0.5)
+    y_title = simplify(fontsize * 2)
     x_msg = simplify(fontsize * 0.8)
-    y_msg = height - caption_size
+    y_msg = height - title_size
     textcolor = isempty(fontcolor) ? "black" : fontcolor
-    caption_color = textcolor
+    title_color = textcolor
     if isempty(fontcolor) && startswith(bgcolor, "#") && isdarkcolor(parse(Gray, bgcolor))
-        caption_color = "white"
+        title_color = "white"
     end
     bg_fill = isempty(bgcolor) ? "url(#$fig_id-background)" : bgcolor
     details_bg_fill = isempty(bgcolor) ? "white" : bgcolor
@@ -78,9 +78,9 @@ function write_svgheader(io::IO, fig_id, width, height,
                 font-size: $(simplify(fontsize))px;
                 fill: $textcolor;
             }
-            text#$fig_id-caption {
-                font-size: $(caption_size)px;
-                fill: $caption_color;
+            text#$fig_id-title {
+                font-size: $(title_size)px;
+                fill: $title_color;
                 text-anchor: middle;
             }
             #$fig_id-bg {
@@ -105,7 +105,7 @@ function write_svgheader(io::IO, fig_id, width, height,
                 opacity: 0.8;
             }
             text#$fig_id-details{
-                fill: $caption_color;
+                fill: $title_color;
             }
         """)
     isempty(fontcolor) && print(io,
@@ -118,12 +118,13 @@ function write_svgheader(io::IO, fig_id, width, height,
     dataxstep = timeunit !== :none ? " data-xstep=\"$xstep\"" : ""
     datatunit = timeunit !== :none ? " data-tunit=\"$timeunit\"" : ""
     datadelay = timeunit !== :none ? " data-delay=\"$delay\"" : ""
+    stitle = escape_html(title)
     print(io,
         """
         </style>
         <g id="$fig_id-frame" clip-path="url(#$fig_id-clip)">
         <rect id="$fig_id-bg" x="0" y="0" width="$w" height="$h"/>
-        <text id="$fig_id-caption" x="$x_cap" y="$y_cap">$title</text>
+        <text id="$fig_id-title" x="$x_title" y="$y_title">$stitle</text>
         <g id="$fig_id-viewport" transform="scale(1)"$dataxstep$datatunit$datadelay>
         """)
 end


### PR DESCRIPTION
This is a modified version of PR #67. This solves issue #66.

I used to call the text a "caption", but I have taken this opportunity to rename it a ”title”. The reason is its shorter length.